### PR TITLE
Use the types file from the dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "browser": "./lib/index.js",
   "module": "./module/index.js",
-  "types": "./src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/lifeomic/abac.git"


### PR DESCRIPTION
When consuming the types from npm, the current file reference doesn't exist