### PR TITLE
add policyRequiresAttribute helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -320,6 +320,22 @@ const privilegesLenient = (policy, attributes) => {
 const privilegesSync = deprecate(privilegesLenient,
   '@lifeomic/abac privilegesSync(...) is deprecated. Use privilegesLenient(...) instead.');
 
+/**
+ * Synchronously determines if a given attribute path is in the list of rules
+ * for a given policy. This may be useful for determining if additional metadata
+ * should be fetched before enforcing a policy.
+ *
+ * @param {object} policy - the policy to check
+ * @param {string} attribute - the attribute path, e.g. 'user.patients'
+ * @returns {Boolean} True if the attribute is in the rules list
+ */
+const policyRequiresAttribute = (policy, attribute) => {
+  const rules = Object.values(policy.rules)
+    .filter(rule => Array.isArray(rule))
+    .reduce((left, right) => left.concat(right), []);
+  return rules.some(rule => rule.hasOwnProperty(attribute));
+};
+
 export {
   validate,
   merge,
@@ -331,5 +347,6 @@ export {
   enforceAny,
   privileges,
   privilegesLenient,
-  privilegesSync /* deprecated */
+  privilegesSync /* deprecated */,
+  policyRequiresAttribute
 };

--- a/test/policyRequiresAttribute.test.js
+++ b/test/policyRequiresAttribute.test.js
@@ -1,0 +1,22 @@
+import { policyRequiresAttribute } from '../dist';
+import test from 'ava';
+
+test('should return true when attribute is required', t => {
+  const policy = {
+    rules: {
+      accessAdmin: false,
+      writeData: true,
+      readData: [
+        {
+          'user.patients': {
+            comparison: 'includes',
+            target: 'resource.subject'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(policyRequiresAttribute(policy, 'user.patients'));
+  t.false(policyRequiresAttribute(policy, 'user.sobaNoodles'));
+});


### PR DESCRIPTION
Extracting this for re-use.

As we start adopting more conditional fetching of additional metadata based on attributes present in the policy, this will become more common. May as well share it so consumers don't have to think about the structure of the policy as much.