### PR TITLE
fix typings/README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ abac.enforceLenient(operationName, policy, attributes);
 abac.enforceAny(operationName, policy, attributes);
 abac.privileges(policy, attributes);
 abac.privilegesLenient(policy, attributes);
+abac.policyRequiresAttribute(policy, attribute);
 ```
 
 See unit tests in `/test` folder - many good examples.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -112,3 +112,14 @@ export type AbacRuleComparison = (
    * @throws {Error} Error if the policy is invalid
    */
   export function privileges(policy: AbacReducedPolicy, attributes: object): string[];
+
+  /**
+   * Synchronously determines if a given attribute path is in the list of rules
+   * for a given policy. This may be useful for determining if additional metadata
+   * should be fetched before enforcing a policy.
+   *
+   * @param {object} policy - the policy to check
+   * @param {string} attribute - the attribute path, e.g. 'user.patients'
+   * @returns {boolean} True if the attribute is in the rules list
+   */
+  export function policyRequiresAttribute(policy: AbacReducedPolicy, attribute: string): boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,7 @@ const privilegesSync = deprecate(privilegesLenient,
  *
  * @param {object} policy - the policy to check
  * @param {string} attribute - the attribute path, e.g. 'user.patients'
- * @returns {Boolean} True if the attribute is in the rules list
+ * @returns {boolean} True if the attribute is in the rules list
  */
 const policyRequiresAttribute = (policy, attribute) => {
   const rules = Object.values(policy.rules)


### PR DESCRIPTION
Oops. Forgot to update the types file and add an example in the README.