### PR TITLE
Add in comparison that is the inverse of includes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,10 @@ const compare = (condition, value, attributes) => {
       if (compareValue === undefined) return undefined;
       return Array.isArray(value) && value.includes(compareValue);
 
+    case 'in':
+      if (compareValue === undefined) return undefined;
+      return Array.isArray(compareValue) && compareValue.includes(value);
+
     case 'equals':
       if (compareValue === undefined) return undefined;
       return value === compareValue;
@@ -119,11 +123,9 @@ const compare = (condition, value, attributes) => {
       if (compareValue === undefined) return undefined;
       return Array.isArray(value) && compareValue.every(x => value.includes(x));
 
-    // It is ok to ignore this line because the policy should be validated
-    // before this method executes making this execution impossible
-    /* istanbul ignore next */
     default:
-      throw new Error(`unknown comparison type: ${condition.comparison}`);
+      // for unknown comparison types simply deny access:
+      return false;
   }
 };
 

--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -7,8 +7,7 @@
     {
       "properties": {
         "comparison": {
-          "type": "string",
-          "const": "superset"
+          "type": "string"
         },
         "value": {
           "type": "array",
@@ -23,8 +22,7 @@
     {
       "properties": {
         "comparison" : {
-          "type": "string",
-          "enum": ["equals", "includes"]
+          "type": "string"
         },
         "value": {
           "type": "string"
@@ -36,9 +34,8 @@
     {
       "properties": {
         "comparison": {
-          "type": "string",
-          "enum": ["equals", "includes", "superset"]
-        }, 
+          "type": "string"
+        },
         "target": {
           "type": "string",
           "pattern": "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$a-zA-Z_][$0-9a-zA-Z_]*)*$"

--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -7,7 +7,8 @@
     {
       "properties": {
         "comparison": {
-          "type": "string"
+          "type": "string",
+          "enum": ["superset", "in"]
         },
         "value": {
           "type": "array",
@@ -21,8 +22,9 @@
     },
     {
       "properties": {
-        "comparison" : {
-          "type": "string"
+        "comparison": {
+          "type": "string",
+          "enum": ["includes", "equals"]
         },
         "value": {
           "type": "string"
@@ -34,7 +36,8 @@
     {
       "properties": {
         "comparison": {
-          "type": "string"
+          "type": "string",
+          "enum": ["superset", "in", "equals", "includes"]
         },
         "target": {
           "type": "string",
@@ -48,11 +51,11 @@
       "properties": {
         "comparison": {
           "type": "string",
-          "const": "exists"
+          "not": {"enum": ["superset", "in", "equals", "includes"]}
         }
       },
       "required": ["comparison"],
-      "additionalProperties": false
+      "additionalProperties": true
     }
   ]
 }

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -181,6 +181,112 @@ test('returns false for invalid operation names', t => {
   t.false(enforce('not-an-operation', {rules: {}}, {}));
 });
 
+test('returns false for permissions containing unknown comparisons and target', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'not-entirely-unlike',
+            target: 'user.favoriteDrink'
+          }
+        }
+      ],
+      createData: true
+    }
+  };
+
+  t.false(enforce('readData', policy, {user: {favoriteDrink: 'tea'}, resource: {type: 'sort of tea'}}));
+  t.true(enforce('createData', policy, {user: {favoriteDrink: 'tea'}, resource: {type: 'sort of tea'}}));
+});
+
+test('returns false for permissions containing unknown comparisons and value', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'not-entirely-unlike',
+            value: 'tea'
+          }
+        }
+      ],
+      createData: true
+    }
+  };
+
+  t.false(enforce('readData', policy, {resource: {type: 'sort of tea'}}));
+  t.true(enforce('createData', policy, {resource: {type: 'sort of tea'}}));
+});
+
+test('supports the in comparison with target', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'in',
+            target: 'user.favoriteDrinks'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {user: {favoriteDrinks: ['tea', 'coffee']}, resource: {type: 'tea'}}));
+});
+
+test('supports the in comparison with target', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'in',
+            target: 'user.favoriteDrinks'
+          }
+        }
+      ]
+    }
+  };
+
+  t.false(enforce('readData', policy, {resource: {type: 'tea'}}));
+});
+
+test('supports the in comparison with value', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'in',
+            value: ['tea', 'coffee']
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {resource: {type: 'tea'}}));
+});
+
+test('supports the in comparison with value', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'in',
+            value: ['tea', 'coffee']
+          }
+        }
+      ]
+    }
+  };
+
+  t.false(enforce('readData', policy, {resource: {type: 'chai'}}));
+});
+
 test('A policy with a new operation works as expected', t => {
   const policy = {
     rules: {

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -121,6 +121,23 @@ test('Missing comparison field should not validate', t => {
   t.throws(() => validate(policy), Error);
 });
 
+test('Wrong value type should not validate', t => {
+  const policy = {
+    rules: {
+      accessAdmin: [
+        {
+          'user.groups': {
+            comparison: 'includes',
+            value: ['A', 'B']
+          }
+        }
+      ]
+    }
+  };
+
+  t.throws(() => validate(policy), Error);
+});
+
 test('Empty rule list should not validate', t => {
   const policy = {
     rules: {
@@ -199,6 +216,23 @@ test('Allows policies containing unknown comparisons and value', t => {
           'resource.type': {
             comparison: 'not-entirely-unlike',
             value: 'tea'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(validate(policy));
+});
+
+test('Allows policies containing unknown comparisons and arbitrary other fields', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'not-entirely-unlike',
+            flavor: 'tea'
           }
         }
       ]

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -173,3 +173,37 @@ test('A policy with a new operation is allowed', t => {
 
   t.true(validate(policy));
 });
+
+test('Allows policies containing unknown comparisons and target', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'not-entirely-unlike',
+            target: 'user.favoriteDrink'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(validate(policy));
+});
+
+test('Allows policies containing unknown comparisons and value', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'resource.type': {
+            comparison: 'not-entirely-unlike',
+            value: 'tea'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(validate(policy));
+});


### PR DESCRIPTION
Also relax the constraints on comparisons so that unknown
comparisons don't fail validation and instead result in
denied access. Being more lenient on comparisons will make
it much easier to roll out new comparisons without breaking
everything.