### PR TITLE
Traverse attribute arrays during ABAC evaluation

### DIFF
--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -41,7 +41,7 @@
         },
         "target": {
           "type": "string",
-          "pattern": "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$a-zA-Z_][$0-9a-zA-Z_]*)*$"
+          "pattern": "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$0-9a-zA-Z_]*)*$"
         }
       },
       "required": ["comparison", "target"],

--- a/src/schemas/Rule.json
+++ b/src/schemas/Rule.json
@@ -4,7 +4,7 @@
   "description": "An individual ABAC policy rule",
   "type": "object",
   "patternProperties": {
-    "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$0-9a-zA-Z_]*)*$": {
+    "^(([$a-zA-Z_][$0-9a-zA-Z_]*)|\\*)(\\.([$0-9a-zA-Z_]*)|\\*)*$": {
       "$ref": "Comparison"
     }
   },

--- a/src/schemas/Rule.json
+++ b/src/schemas/Rule.json
@@ -4,7 +4,7 @@
   "description": "An individual ABAC policy rule",
   "type": "object",
   "patternProperties": {
-    "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$a-zA-Z_][$0-9a-zA-Z_]*)*$": {
+    "^[$a-zA-Z_][$0-9a-zA-Z_]*(\\.[$0-9a-zA-Z_]*)*$": {
       "$ref": "Comparison"
     }
   },

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -333,3 +333,39 @@ test('enforceAny returns false when none of the operations are allowed', t => {
 
   t.false(enforceAny(['readData', 'readAnonData'], policy, {}));
 });
+
+test('rules can reference vaules in an array', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'array.0.value': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {array: [{value: 'test'}]}));
+  t.false(enforce('readData', policy, {array: [{value: 'bogus'}]}));
+});
+
+test('rules can target array values', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          value: {
+            comparison: 'equals',
+            target: 'array.0.value'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {value: 'test', array: [{value: 'test'}]}));
+  t.false(enforce('readData', policy, {value: 'test', array: [{value: 'bogus'}]}));
+});

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -369,3 +369,118 @@ test('rules can target array values', t => {
   t.true(enforce('readData', policy, {value: 'test', array: [{value: 'test'}]}));
   t.false(enforce('readData', policy, {value: 'test', array: [{value: 'bogus'}]}));
 });
+
+test('rules can end with a wildcard', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.*': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {some: {a: 'test', b: 'test'}}));
+  t.false(enforce('readData', policy, {some: {a: 'test', b: 'bogus'}}));
+  t.true(enforce('readData', policy, {some: ['test', 'test']}));
+  t.false(enforce('readData', policy, {some: ['test', 'bogus']}));
+});
+
+test('rules can start with a wildcard', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          '*.some': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {a: {some: 'test'}, b: {some: 'test'}}));
+  t.false(enforce('readData', policy, {a: {some: 'bogus'}, b: {some: 'test'}}));
+  t.true(enforce('readData', policy, [{some: 'test'}, {some: 'test'}]));
+  t.false(enforce('readData', policy, [{some: 'test'}, {some: 'bogus'}]));
+});
+
+test('rules can contain a wildcard', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.*.property': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {some: {a: {property: 'test'}, b: {property: 'test'}}}));
+  t.false(enforce('readData', policy, {some: {a: {property: 'test'}, b: {property: 'bogus'}}}));
+  t.true(enforce('readData', policy, {some: [{property: 'test'}, {property: 'test'}]}));
+  t.false(enforce('readData', policy, {some: [{property: 'test'}, {property: 'bogus'}]}));
+});
+
+test('wildcard evaluation fails if attribute resolution fails', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.*.property': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.false(enforce('readData', policy, {}));
+  t.false(enforce('readData', policy, {some: {property: 'test'}}));
+  t.false(enforce('readData', policy, {some: [{property: 'test'}, {bogus: 'test'}]}));
+});
+
+test('wildcard evaluation fails if target resolution fails', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.*.property': {
+            comparison: 'equals',
+            target: 'missing'
+          }
+        }
+      ]
+    }
+  };
+
+  t.false(enforce('readData', policy, {some: [{property: 'test'}, {property: 'test'}]}));
+});
+
+test('rules can contain multiple wildcards', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.*.property.*': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {some: [{property: ['test', 'test']}, {property: ['test', 'test']}]}));
+  t.false(enforce('readData', policy, {some: [{property: ['test', 'bogus']}, {property: ['test', 'test']}]}));
+  t.false(enforce('readData', policy, {some: [{property: ['test', 'test']}, {bogus: ['test', 'test']}]}));
+});


### PR DESCRIPTION
My intent is to facilitate a policy like the following:

```javascript
{
  rules: {
    readData: [
      {
        'resource.type': {
          comparison: 'equals',
          value: 'fhir-search'
        },
        'query.limit.1.value': {
          comparison: 'equals',
          value: 0
        },
        'query.from.*.table': {
          comparison: 'in',
          value: ['patient', 'procedure', 'observation']
        }
      }
    ]
  }
}
```