### PR TITLE
Additional ABAC comparisons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ const merge = (policies) => {
  * @param {array} path - array of path segments
  */
 const getAttributeValues = (attributes, path) => {
-  if (!attributes) {
+  if (attributes === undefined) {
     return [];
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,25 +83,29 @@ const getAttributeValues = (attributes, path) => {
 
   const name = path[0];
 
-  if (name === '*') {
-    const keys = Object.keys(attributes);
-    let values = [];
+  switch (name) {
+    case '*':
+      const keys = Object.keys(attributes);
+      let values = [];
 
-    for (const key of keys) {
-      const result = getAttributeValues(attributes[key], path.slice(1));
+      for (const key of keys) {
+        const result = getAttributeValues(attributes[key], path.slice(1));
 
-      // If a single sub-path fails to evaluate fail the entire traversal.
-      if (result.length === 0) {
-        values = [];
-        break;
-      } else {
-        values = values.concat(result);
+        // If a single sub-path fails to evaluate fail the entire traversal.
+        if (result.length === 0) {
+          values = [];
+          break;
+        } else {
+          values = values.concat(result);
+        }
       }
-    }
 
-    return values;
-  } else {
-    return getAttributeValues(attributes[name], path.slice(1));
+      return values;
+    case '%keys':
+      return getAttributeValues(Object.keys(attributes), path.slice(1));
+    default:
+      const unescapedName = name.replace(/^%%/, '%');
+      return getAttributeValues(attributes[unescapedName], path.slice(1));
   }
 };
 

--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -27,7 +27,7 @@
           "enum": ["includes", "equals"]
         },
         "value": {
-          "type": "string"
+          "type": ["number", "string"]
         }
       },
       "required": ["comparison", "value"],

--- a/src/schemas/Rule.json
+++ b/src/schemas/Rule.json
@@ -4,7 +4,7 @@
   "description": "An individual ABAC policy rule",
   "type": "object",
   "patternProperties": {
-    "^(([$a-zA-Z_][$0-9a-zA-Z_]*)|\\*)(\\.([$0-9a-zA-Z_]*)|\\*)*$": {
+    "^(([$%a-zA-Z_][$%0-9a-zA-Z_]*)|\\*)(\\.([$%0-9a-zA-Z_]*)|\\*)*$": {
       "$ref": "Comparison"
     }
   },

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -484,3 +484,21 @@ test('rules can contain multiple wildcards', t => {
   t.false(enforce('readData', policy, {some: [{property: ['test', 'bogus']}, {property: ['test', 'test']}]}));
   t.false(enforce('readData', policy, {some: [{property: ['test', 'test']}, {bogus: ['test', 'test']}]}));
 });
+
+test('rules can use numeric comparison values', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.value': {
+            comparison: 'equals',
+            value: 0
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {some: {value: 0}}));
+  t.false(enforce('readData', policy, {some: {value: 1}}));
+});

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -502,3 +502,85 @@ test('rules can use numeric comparison values', t => {
   t.true(enforce('readData', policy, {some: {value: 0}}));
   t.false(enforce('readData', policy, {some: {value: 1}}));
 });
+
+test('rules can match object keys', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'some.object.%keys.*': {
+            comparison: 'in',
+            value: ['a', 'b', 'c']
+          },
+          'some.object.%keys.length': {
+            comparison: 'equals',
+            value: 2
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {some: {object: {a: 1, b: 2}}}));
+  t.false(enforce('readData', policy, {some: {object: {a: 1, d: 2}}}));
+  t.false(enforce('readData', policy, {some: {object: {a: 1, b: 2, c: 3}}}));
+});
+
+test('rules can match top-level object keys', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          '%keys.*': {
+            comparison: 'in',
+            value: ['a', 'b', 'c']
+          },
+          '%keys.length': {
+            comparison: 'equals',
+            value: 2
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {a: 1, b: 2}));
+  t.false(enforce('readData', policy, {a: 1, d: 2}));
+  t.false(enforce('readData', policy, {a: 1, b: 2, c: 3}));
+});
+
+test('rules can match literal %keys attribute', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          'object.%%keys': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {object: {'%keys': 'test'}}));
+  t.false(enforce('readData', policy, {object: {'%keys': 'bogus'}}));
+});
+
+test('rules can match top-level literal %keys attribute', t => {
+  const policy = {
+    rules: {
+      readData: [
+        {
+          '%%keys': {
+            comparison: 'equals',
+            value: 'test'
+          }
+        }
+      ]
+    }
+  };
+
+  t.true(enforce('readData', policy, {'%keys': 'test'}));
+  t.false(enforce('readData', policy, {'%keys': 'bogus'}));
+});


### PR DESCRIPTION
This should support policies like the following:

```javascript
{
  rules: {
    readData: [
      {
        'query.columns.*.aggregations.%keys.*': {
          comparison: 'in',
          value: ['stats']
        },
        'query.limit.*.value': {
          comparison: 'equals',
          value: 0
        }
      }
    ]
  }
}
```
This is useful for policies against Elasticsearch queries where object keys are significant.