### PR TITLE
Do not throw when enforcing invalid policy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,8 +251,12 @@ const reduceSync = deprecate(reduce,
  * @throws {Error} Error if the policy is invalid
  */
 const enforce = (operation, policy, attributes) => {
-  // Before using the policy, make sure it's valid
-  validate(policy);
+  try {
+    // Before using the policy, make sure it's valid
+    validate(policy);
+  } catch (error) {
+    return false;
+  }
 
   // It is safe to ignore the injection attach here because the operation name has been validated
   // against the allowed operation names
@@ -277,8 +281,12 @@ const enforce = (operation, policy, attributes) => {
  * @throws {Error} Error if the policy is invalid
  */
 const enforceLenient = (operation, policy, attributes) => {
-  // Before using the policy, make sure it's valid
-  validate(policy);
+  try {
+    // Before using the policy, make sure it's valid
+    validate(policy);
+  } catch (error) {
+    return false;
+  }
 
   // It is safe to ignore the injection attach here because the operation name has been validated
   // against the allowed operation names

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -607,3 +607,18 @@ test('rules can match top-level literal %keys attribute', t => {
   t.true(enforce('readData', policy, {'%keys': 'test'}));
   t.false(enforce('readData', policy, {'%keys': 'bogus'}));
 });
+
+test('returns false for invalid policy', t => {
+  const policy = {
+    rules: {
+      readData: {
+        '?!*bogus*!?': {
+          comparison: 'equals',
+          value: 'test'
+        }
+      }
+    }
+  };
+
+  t.false(enforce('readData', policy, {}));
+});

--- a/test/enforceLenient.test.js
+++ b/test/enforceLenient.test.js
@@ -49,3 +49,18 @@ test('Partially evaluated policy should enforce properly', t => {
 test('returns false for invalid operation names', t => {
   t.false(enforceLenient('not-an-operation', {rules: {}}));
 });
+
+test('returns false for invalid policy', t => {
+  const policy = {
+    rules: {
+      readData: {
+        '?!*bogus*!?': {
+          comparison: 'equals',
+          value: 'test'
+        }
+      }
+    }
+  };
+
+  t.false(enforceLenient('readData', policy, {}));
+});


### PR DESCRIPTION
Throwing an error when enforcing an invalid policy makes it
difficult to upgrade the ABAC library across an ecosystem of
microservices. Returning an "unauthorized" response is a more
graceful failure mode. Consumers that strictly require a valid
policy document can explicitly call 'validate()'.