### PR TITLE
LO-7197 policyRequiresAttribute: prefix and target

### DIFF
--- a/test/policyRequiresAttribute.test.js
+++ b/test/policyRequiresAttribute.test.js
@@ -12,11 +12,29 @@ test('should return true when attribute is required', t => {
             comparison: 'includes',
             target: 'resource.subject'
           }
+        },
+        {
+          'user.consents.*.tags': {
+            comparison: 'superset',
+            target: 'resource.tags'
+          }
+        },
+        {
+          'something': {
+            comparison: 'equals',
+            target: 'other.value'
+          }
         }
       ]
     }
   };
 
   t.true(policyRequiresAttribute(policy, 'user.patients'));
+  t.true(policyRequiresAttribute(policy, 'resource.subject'));
+  t.true(policyRequiresAttribute(policy, 'user.consents'));
+  t.true(policyRequiresAttribute(policy, 'other'));
+
+  t.false(policyRequiresAttribute(policy, 'consent')); // not a prefix
+  t.false(policyRequiresAttribute(policy, 'some')); // some !== something
   t.false(policyRequiresAttribute(policy, 'user.sobaNoodles'));
 });


### PR DESCRIPTION
Support attribute targets and path prefix matching when determining
whether an attribute is required by a policy.