### PR TITLE
PHC-561 - Add extract function for ABAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ This module is suitable for use in both UIs and backend node.js services.
 yarn install @lifeomic/abac
 ```
 
+## Terminology
+* Rules
+    * Comparison
+        * equals: Value being checked is exactly equal to the value defined in the ABAC policy
+        * notEquals: Value being checked does not equal the value defined in the ABAC policy
+        * in: value being checked is contained within the array in ABAC policy
+        * notIn: value not in ABAC array
+        * includes: array of values includes the value in the ABAC policy
+        * notIncludes: array of values does not include value listed in ABAC policy
+        * superset: array of values is a superset of the array in the ABAC policy
+        * subset: array of values is a subset of the array in the ABAC policy
+    * Target
+        * Value of another attribute
+    * Value
+        * Literal value
+
 ## Usage
 
 **TypeScript usage:**

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ import * as abac from '@lifeomic/abac';
 abac.validate(policy);
 abac.merge(policies);
 abac.reduce(policy, attributes);
+abac.extract(policy, privilege, attribute);
 abac.enforce(operationName, policy, attributes);
 abac.enforceLenient(operationName, policy, attributes);
 abac.enforceAny(operationName, policy, attributes);

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ yarn install @lifeomic/abac
         * in: value being checked is contained within the array in ABAC policy
         * notIn: value not in ABAC array
         * includes: array of values includes the value in the ABAC policy
-        * notIncludes: array of values does not include value listed in ABAC policy
         * superset: array of values is a superset of the array in the ABAC policy
         * subset: array of values is a subset of the array in the ABAC policy
     * Target
@@ -37,7 +36,7 @@ import * as abac from '@lifeomic/abac';
 abac.validate(policy);
 abac.merge(policies);
 abac.reduce(policy, attributes);
-abac.extract(policy, privilege, attribute);
+abac.extract(policy, privileges, attribute);
 abac.enforce(operationName, policy, attributes);
 abac.enforceLenient(operationName, policy, attributes);
 abac.enforceAny(operationName, policy, attributes);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ajv": "^6.5.0",
     "babel-runtime": "^6.26.0",
     "fast-deep-equal": "^3.1.3",
-    "util-deprecate": "^1.0.2"
+    "util-deprecate": "^1.0.2",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@lifeomic/eslint-plugin-node": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "ajv": "^6.5.0",
     "babel-runtime": "^6.26.0",
     "fast-deep-equal": "^3.1.3",
-    "util-deprecate": "^1.0.2",
-    "uuid": "^3.3.2"
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@lifeomic/eslint-plugin-node": "^1.1.0",
@@ -41,7 +40,8 @@
     "eslint": "^4.19.1",
     "nyc": "^11.8.0",
     "sinon": "^5.0.7",
-    "tap-xunit": "^2.3.0"
+    "tap-xunit": "^2.3.0",
+    "uuid": "^3.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,6 +54,18 @@ export type AbacRuleComparison = (
   export function reduce(policy: AbacReducedPolicy, attributes: object): AbacReducedPolicy;
 
   /**
+   * Extract a rule for a given privilege and attribute from the policy.
+   * The function's intended use is to provide the comparison and values (e.g. uuids) for a resource type
+   * e.g. resource.cohort: {comparison: 'equals', target: uuid}
+   * @param policy - the policy to evaluate
+   * @param privilege - the privilege to use for the evaluation
+   * @param attribute - the attribute to use for the evaluation
+   * @returns {object} An array of rules matching the privilege and attribute
+   * @throws {Error} Error if the policy is invalid
+   */
+  export function extract(policy: AbacReducedPolicy, privilege: string, attribute: string): AbacRule[];
+
+  /**
    * Check whether the given policy allows the operation with the given attributes.
    * @param {string} operation - the requested operation
    * @param {object} policy - the policy to use to check access

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,16 +54,16 @@ export type AbacRuleComparison = (
   export function reduce(policy: AbacReducedPolicy, attributes: object): AbacReducedPolicy;
 
   /**
-   * Extract a rule for a given privilege and attribute from the policy.
+   * Extract a rule for a given list of privileges and attribute from the policy.
    * The function's intended use is to provide the comparison and values (e.g. uuids) for a resource type
-   * e.g. resource.cohort: {comparison: 'equals', target: uuid}
+   * e.g. resource.cohort: {comparison: 'equals', value: uuid}
    * @param policy - the policy to evaluate
-   * @param privilege - the privilege to use for the evaluation
+   * @param privileges - the privileges to use for the evaluation
    * @param attribute - the attribute to use for the evaluation
-   * @returns {object} An array of rules matching the privilege and attribute
+   * @returns {object} An array of rules matching the privileges and attribute
    * @throws {Error} Error if the policy is invalid
    */
-  export function extract(policy: AbacReducedPolicy, privilege: string, attribute: string): AbacRule[];
+  export function extract(policy: AbacReducedPolicy, privileges: string[], attribute: string): AbacRuleComparison[];
 
   /**
    * Check whether the given policy allows the operation with the given attributes.

--- a/src/index.js
+++ b/src/index.js
@@ -68,17 +68,15 @@ const merge = (policies) => {
   return {rules: result};
 };
 
-const extract = (policy, privilege, attribute) => {
+// returns an array of values for each instance of the attribute under the given privileges
+const extract = (policy, privileges, attribute) => {
   validate(policy);
-  return Object.entries(policy.rules).map(([operation, rules]) => {
-    if (Array.isArray(rules) && privilege === operation) {
-      for (const rule of rules) {
-        if (rule[attribute]) {
-          return rule[attribute];
-        }
-      }
+  const comparisons = Object.entries(policy.rules).map(([operation, rules]) => {
+    if (Array.isArray(rules) && privileges.includes(operation)) {
+      return rules.map(rule => rule[attribute]).filter(Boolean);
     }
   }).filter(Boolean);
+  return comparisons.flat(1);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,19 @@ const merge = (policies) => {
   return {rules: result};
 };
 
+const extract = (policy, privilege, attribute) => {
+  validate(policy);
+  return Object.entries(policy.rules).map(([operation, rules]) => {
+    if (Array.isArray(rules) && privilege === operation) {
+      for (const rule of rules) {
+        if (rule[attribute]) {
+          return rule[attribute];
+        }
+      }
+    }
+  }).filter(Boolean);
+};
+
 /**
  * Get a list of all values matching the path (including wildcards).
  * @param {object} attributes - attributes as nested objects
@@ -431,6 +444,7 @@ export {
   enforceLenient,
   enforceSync /* deprecated */,
   enforceAny,
+  extract,
   privileges,
   privilegesLenient,
   privilegesSync /* deprecated */,

--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -64,37 +64,6 @@
       "properties": {
         "comparison": {
           "type": "string",
-          "enum": ["superset", "subset", "in", "notIn"]
-        },
-        "target": {
-          "type": "array",
-          "items" : {
-            "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
-          }
-        }
-      },
-      "required": ["comparison", "target"],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "comparison": {
-          "type": "string",
-          "enum": ["equals", "notEquals"]
-        },
-        "target": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
-        }
-      },
-      "required": ["comparison", "target"],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "comparison": {
-          "type": "string",
           "not": {"enum": ["superset", "subset", "in", "equals", "includes", "notEquals", "notIn"]}
         }
       },

--- a/src/schemas/Comparison.json
+++ b/src/schemas/Comparison.json
@@ -64,6 +64,37 @@
       "properties": {
         "comparison": {
           "type": "string",
+          "enum": ["superset", "subset", "in", "notIn"]
+        },
+        "target": {
+          "type": "array",
+          "items" : {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          }
+        }
+      },
+      "required": ["comparison", "target"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "comparison": {
+          "type": "string",
+          "enum": ["equals", "notEquals"]
+        },
+        "target": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        }
+      },
+      "required": ["comparison", "target"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "comparison": {
+          "type": "string",
           "not": {"enum": ["superset", "subset", "in", "equals", "includes", "notEquals", "notIn"]}
         }
       },

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -1,0 +1,107 @@
+import { extract } from '../dist';
+import uuid from 'uuid';
+import test from 'ava';
+
+test('should return rule values', t => {
+  const expectedId1 = uuid();
+  const expectedId2 = uuid();
+  const policy = {
+    rules: {
+      accessAdmin: false,
+      writeData: true,
+      readData: [
+        {
+          'user.patients': {
+            comparison: 'includes',
+            target: 'resource.subject'
+          }
+        },
+        {
+          'resource.cohort': {
+            comparison: 'includes',
+            target: [expectedId1, expectedId2]
+          }
+        },
+        {
+          'something': {
+            comparison: 'equals',
+            target: 'other.value'
+          }
+        }
+      ]
+    }
+  };
+
+  t.deepEqual(extract(policy, 'readData', 'resource.cohort'), [{target: [expectedId1, expectedId2], comparison: 'includes'}]);
+});
+
+test('should return attribute values and comparison value only for privilege to be checked', t => {
+  const expectedId1 = uuid();
+  const expectedId2 = uuid();
+  const policy = {
+    rules: {
+      accessAdmin: true,
+      writeData: [{
+        'resource.cohort': {
+          comparison: 'equals',
+          target: expectedId1
+        }
+      }],
+      readData: [
+        {
+          'user.patients': {
+            comparison: 'includes',
+            target: 'resource.subject'
+          }
+        },
+        {
+          'resource.cohort': {
+            comparison: 'equals',
+            target: [expectedId1, expectedId2]
+          }
+        },
+        {
+          'something': {
+            comparison: 'equals',
+            target: 'other.value'
+          }
+        }
+      ]
+    }
+  };
+
+  t.deepEqual(extract(policy, 'writeData', 'resource.cohort'), [{target: expectedId1, comparison: 'equals'}]);
+});
+
+test('No rules should be extracted for a boolean operation', t => {
+  const expectedId1 = uuid();
+  const expectedId2 = uuid();
+  const policy = {
+    rules: {
+      accessAdmin: true,
+      writeData: true,
+      readData: [
+        {
+          'user.patients': {
+            comparison: 'includes',
+            target: 'resource.subject'
+          }
+        },
+        {
+          'resource.cohort': {
+            comparison: 'equals',
+            target: [expectedId1, expectedId2]
+          }
+        },
+        {
+          'something': {
+            comparison: 'equals',
+            target: 'other.value'
+          }
+        }
+      ]
+    }
+  };
+
+  t.deepEqual(extract(policy, 'writeData', 'resource.cohort'), []);
+});

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -17,9 +17,9 @@ test('should return rule values', t => {
           }
         },
         {
-          'resource.cohort': {
-            comparison: 'in',
-            target: [expectedId1, expectedId2]
+          'resource.cohorts': {
+            comparison: 'subset',
+            value: [expectedId1, expectedId2]
           }
         },
         {
@@ -32,7 +32,7 @@ test('should return rule values', t => {
     }
   };
 
-  t.deepEqual(extract(policy, 'readData', 'resource.cohort'), [{target: [expectedId1, expectedId2], comparison: 'in'}]);
+  t.deepEqual(extract(policy, ['readData'], 'resource.cohorts'), [{value: [expectedId1, expectedId2], comparison: 'subset'}]);
 });
 
 test('should return attribute values and comparison value only for privilege to be checked', t => {
@@ -42,9 +42,9 @@ test('should return attribute values and comparison value only for privilege to 
     rules: {
       accessAdmin: true,
       writeData: [{
-        'resource.cohort': {
-          comparison: 'equals',
-          target: expectedId1
+        'resource.cohorts': {
+          comparison: 'includes',
+          value: expectedId1
         }
       }],
       readData: [
@@ -55,9 +55,9 @@ test('should return attribute values and comparison value only for privilege to 
           }
         },
         {
-          'resource.cohort': {
-            comparison: 'in',
-            target: [expectedId1, expectedId2]
+          'resource.cohorts': {
+            comparison: 'subset',
+            value: [expectedId1, expectedId2]
           }
         },
         {
@@ -70,7 +70,45 @@ test('should return attribute values and comparison value only for privilege to 
     }
   };
 
-  t.deepEqual(extract(policy, 'writeData', 'resource.cohort'), [{target: expectedId1, comparison: 'equals'}]);
+  t.deepEqual(extract(policy, ['writeData'], 'resource.cohorts'), [{value: expectedId1, comparison: 'includes'}]);
+});
+
+test('should return attribute values and comparison value for mutliple privileges', t => {
+  const expectedId1 = uuid();
+  const expectedId2 = uuid();
+  const policy = {
+    rules: {
+      accessAdmin: true,
+      readMaskedData: [{
+        'resource.cohorts': {
+          comparison: 'includes',
+          value: expectedId1
+        }
+      }],
+      readData: [
+        {
+          'user.patients': {
+            comparison: 'includes',
+            target: 'resource.subject'
+          }
+        },
+        {
+          'resource.cohorts': {
+            comparison: 'subset',
+            value: [expectedId1, expectedId2]
+          }
+        },
+        {
+          'something': {
+            comparison: 'equals',
+            target: 'other.value'
+          }
+        }
+      ]
+    }
+  };
+
+  t.deepEqual(extract(policy, ['readData', 'readMaskedData'], 'resource.cohorts'), [{value: expectedId1, comparison: 'includes'}, {value: [expectedId1, expectedId2], comparison: 'subset'}]);
 });
 
 test('No rules should be extracted for a boolean operation', t => {
@@ -88,9 +126,9 @@ test('No rules should be extracted for a boolean operation', t => {
           }
         },
         {
-          'resource.cohort': {
-            comparison: 'in',
-            target: [expectedId1, expectedId2]
+          'resource.cohorts': {
+            comparison: 'subset',
+            value: [expectedId1, expectedId2]
           }
         },
         {
@@ -103,5 +141,5 @@ test('No rules should be extracted for a boolean operation', t => {
     }
   };
 
-  t.deepEqual(extract(policy, 'writeData', 'resource.cohort'), []);
+  t.deepEqual(extract(policy, ['writeData'], 'resource.cohorts'), []);
 });

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -7,7 +7,7 @@ test('should return rule values', t => {
   const expectedId2 = uuid();
   const policy = {
     rules: {
-      accessAdmin: false,
+      accessAdmin: true,
       writeData: true,
       readData: [
         {
@@ -18,7 +18,7 @@ test('should return rule values', t => {
         },
         {
           'resource.cohort': {
-            comparison: 'includes',
+            comparison: 'in',
             target: [expectedId1, expectedId2]
           }
         },
@@ -32,7 +32,7 @@ test('should return rule values', t => {
     }
   };
 
-  t.deepEqual(extract(policy, 'readData', 'resource.cohort'), [{target: [expectedId1, expectedId2], comparison: 'includes'}]);
+  t.deepEqual(extract(policy, 'readData', 'resource.cohort'), [{target: [expectedId1, expectedId2], comparison: 'in'}]);
 });
 
 test('should return attribute values and comparison value only for privilege to be checked', t => {
@@ -56,7 +56,7 @@ test('should return attribute values and comparison value only for privilege to 
         },
         {
           'resource.cohort': {
-            comparison: 'equals',
+            comparison: 'in',
             target: [expectedId1, expectedId2]
           }
         },
@@ -89,7 +89,7 @@ test('No rules should be extracted for a boolean operation', t => {
         },
         {
           'resource.cohort': {
-            comparison: 'equals',
+            comparison: 'in',
             target: [expectedId1, expectedId2]
           }
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4782,6 +4782,11 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"


### PR DESCRIPTION
I'm not sure I'm sold myself on this, but I like it better than my other options.

If ABAC is set up for a cohort or list of cohorts, this will provide a way to extract the cohort id(s) from the policy. The ids can then be sent to `cohort-service` to get the patients for them an validate that a user has access to the patient for the resource being requested (which that resource may itself be a patient). This will be used by at least patient-service and fhir-search-service (but potentially several other services)

Other ideas floated:
* Get the patient id that the resource belongs to and find which cohorts the patient id belongs to. Then check if the user has access to any of those cohorts. Requires either loading all of the cohorts for a project and iterating through them to find any that have the patient id or adding a way (new table?) to map patient ids to cohorts. Would need a migration task for existing cohorts and would need to update the data whenever a cohort changed.

* > require the client to also provide a _cohort search parameter that is used to assert the cohort they are using and that they should have access to and that the patient should be in. The downside is that puts an extra constraint on the client

Regardless of whether the `extract` function holds muster, the ajv schema still needs to be updated to account for UUIDs. I assume I need to update the version number here same as I would other commonly used packages:
* merge change
* checkout master `git checkout master` and pull `git pull`
* version: `npm version patch`
* push version with the tag: `git push --follow-tags`