### PR TITLE
PHC-835 - Evaluate boolean values even if attribute is not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,10 @@ const reduceRule = (rule, attributes) => {
   for (const [name, condition] of Object.entries(rule)) {
     const values = getAttributeValues(attributes, name.split('.'));
 
+    if (typeof condition.value === 'boolean' && values.length === 0) {
+      values.push(false);
+    }
+
     if (values.length === 0) {
       result[name] = condition;
     } else {

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -782,3 +782,43 @@ test('rules can use notIn with referenced values', t => {
   t.false(enforce('readData', policy, {object: {key: 2, value: [1, 2]}}));
   t.false(enforce('readData', policy, {object: {key: 3}}));
 });
+
+test('return true for policy with boolean value when attribute is not set', t => {
+  const policy = {
+    'rules': {
+      'readData': [{
+        'resource.cohorts': {
+          'value': '642390ca-4c15-4e7f-b459-28b16def2c2b',
+          'comparison': 'includes'
+        }
+      },
+      {
+        'resource.cohortAffinity': {
+          'value': true, 'comparison': 'notEquals'
+        }
+      }]
+    }
+  };
+  const any = enforce('readData', policy, {});
+  t.true(any);
+});
+
+test('return false for policy with boolean value when attribute is set', t => {
+  const policy = {
+    'rules': {
+      'readData': [{
+        'resource.cohorts': {
+          'value': '642390ca-4c15-4e7f-b459-28b16def2c2b',
+          'comparison': 'includes'
+        }
+      },
+      {
+        'resource.cohortAffinity': {
+          'value': true, 'comparison': 'notEquals'
+        }
+      }]
+    }
+  };
+  const any = enforce('readData', policy, {resource: {cohortAffinity: true}});
+  t.false(any);
+});


### PR DESCRIPTION
This is an alternative approach to https://github.com/lifeomic/terminology-service/pull/89.

I have some reservations about this approach myself (evaluating a condition when its corresponding attribute has not been passed in could cause unforeseen issues. Though it is limited to boolean values, which by definition should be true or false.)

It may be better to just update the calling services and have them explicility set `cohortAffinity: false`