### PR TITLE
PHC-1051: Update typings to allow for optional attributes and check for null in addition to undefined

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,7 +73,7 @@ export type AbacRuleComparison = (
    * @returns {boolean} true iff access is allowed, and false otherwise
    * @throws {Error} Error if the policy is invalid
    */
-  export function enforce(operationName: string, policy: AbacReducedPolicy, attributes: object): boolean;
+  export function enforce(operationName: string, policy: AbacReducedPolicy, attributes?: object): boolean;
 
   /**
    * Performs a check for whether the given policy might
@@ -90,7 +90,7 @@ export type AbacRuleComparison = (
    * @returns {boolean} true iff access is allowed, and false otherwise
    * @throws {Error} Error if the policy is invalid
    */
-  export function enforceLenient(operationName: string, policy: AbacReducedPolicy, attributes: object): boolean;
+  export function enforceLenient(operationName: string, policy: AbacReducedPolicy, attributes?: object): boolean;
 
   /**
    * Check whether the given policy allows one of a list of operations
@@ -101,7 +101,7 @@ export type AbacRuleComparison = (
    * @returns {boolean|string} - the first allowed operation or false
    * @throws {Error} Error if the policy is invalid
    */
-  export function enforceAny(operationName: string[], policy: AbacReducedPolicy, attributes: object): boolean;
+  export function enforceAny(operationName: string[], policy: AbacReducedPolicy, attributes?: object): boolean;
 
   /**
    * Synchronously return the list of privileges that the given policy
@@ -113,7 +113,7 @@ export type AbacRuleComparison = (
    * @returns {string[]} - the list of privileges
    * @throws {Error} Error if the policy is invalid
    */
-  export function privilegesLenient(policy: AbacReducedPolicy, attributes: object): string[];
+  export function privilegesLenient(policy: AbacReducedPolicy, attributes?: object): string[];
 
   /**
    * Return the list of privileges that the given policy
@@ -123,7 +123,7 @@ export type AbacRuleComparison = (
    * @returns {string[]} - the list of privileges
    * @throws {Error} Error if the policy is invalid
    */
-  export function privileges(policy: AbacReducedPolicy, attributes: object): string[];
+  export function privileges(policy: AbacReducedPolicy, attributes?: object): string[];
 
   /**
    * Synchronously determines if a given attribute path is in the list of rules

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,7 +113,7 @@ export type AbacRuleComparison = (
    * @returns {string[]} - the list of privileges
    * @throws {Error} Error if the policy is invalid
    */
-  export function privilegesLenient(policy: AbacReducedPolicy, attributes?: object): string[];
+  export function privilegesLenient(policy: AbacReducedPolicy, attributes: object): string[];
 
   /**
    * Return the list of privileges that the given policy
@@ -123,7 +123,7 @@ export type AbacRuleComparison = (
    * @returns {string[]} - the list of privileges
    * @throws {Error} Error if the policy is invalid
    */
-  export function privileges(policy: AbacReducedPolicy, attributes?: object): string[];
+  export function privileges(policy: AbacReducedPolicy, attributes: object): string[];
 
   /**
    * Synchronously determines if a given attribute path is in the list of rules

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ const extract = (policy, privileges, attribute) => {
  * @param {array} path - array of path segments
  */
 const getAttributeValues = (attributes, path) => {
-  if (attributes === undefined) {
+  if (attributes === undefined || attributes === null) {
     return [];
   }
 


### PR DESCRIPTION
As part of PHC-1051, we found that these typings needed to have an optional flag. Also, to provide a bit more flexibility, the `getAttributeValues` will also properly handle `null` the same way it would `undefined`.