### PR TITLE
Fix release second try.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,20 @@
-name: Release
-
+name: Publish Node.js Package
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - master
+  release:
+    types: [created]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Exit if not on master branch
-      if: endsWith(github.ref, 'master') == false
-      run: exit 0
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12
-        registry-url: https://registry.npmjs.org
-    - name: Build and Test
-      run: |
-        yarn
-        yarn test
-        yarn build
-        npm publish --access public
-      env:
-          NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install
+      - run: yarn test
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -50,4 +50,6 @@ See unit tests in `/test` folder - many good examples.
 ## Release process
 
 Increment the version in `package.json`, make a PR, merge the PR,
-and then finally tag master with a tag like `v4.5.3`.
+and then finally create a new release using the github UI. Creating
+the release will publish the head of master to npm. Name the
+release `vX.Y.Z` to match the version in `package.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/abac",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Lifeomic Attribute Based Access Control Support Module",
   "main": "./dist/index.js",
   "browser": "./lib/index.js",


### PR DESCRIPTION
This is the github recommended way to automate npm package
deployment.

https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

This is a bit more cumbersome than simply pushing a tag, but feels less automagical. Creating the github release will automatically tag the head of master with the release tag, so no need to manually create tags.