### PR TITLE
Fix return type of func enforceAny()

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,7 +101,7 @@ export type AbacRuleComparison = (
    * @returns {boolean|string} - the first allowed operation or false
    * @throws {Error} Error if the policy is invalid
    */
-  export function enforceAny(operationName: string[], policy: AbacReducedPolicy, attributes?: object): boolean;
+  export function enforceAny(operationName: string[], policy: AbacReducedPolicy, attributes?: object): boolean | string;
 
   /**
    * Synchronously return the list of privileges that the given policy


### PR DESCRIPTION
I discovered this problem when debugging https://github.com/lifeomic/fhir-search-service/pull/125

Looks like it doesn't test `src/index.d.ts` in this repo since tests are written in javascript. is this required?