### PR TITLE
Correct `validate` type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/abac",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Lifeomic Attribute Based Access Control Support Module",
   "main": "./dist/index.js",
   "browser": "./lib/index.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ export type AbacRuleComparison = (
    * @returns {boolean} true iff the policy is valid
    * @throws Error if the policy is invalid
    */
-  export function validate(policy: AbacPolicy): boolean;
+  export function validate(policy: AbacPolicy): true;
 
   /**
    * Merge multiple policies into a single policy with the same effect.


### PR DESCRIPTION
## Motivation
This function actually never returns `false` -- it either returns `true` or `throws`. The existing documentation and [the source code](https://github.com/lifeomic/abac/blob/master/src/index.js#L18-L26) confirms that.

I figured it was worth updating -- I mistakenly handled the `false` case from `validate`, when I should have caught errors. I'm hoping this improvement helps the next developer.