### PR TITLE
NO-JIRA: reminder about reversed comparison operators

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Motivation
+
+<!-- Describe _why_ this change should merge. -->
+
+## Checklist
+
+- [] When adding a new comparison operator, a reversed comparison operator is
+also added, or the new comparison operator is added to the
+`TARGETLESS_COMPARISON_OPERATORS` list.

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ export const COMPARISON_REVERSION_MAP = {
   superset: 'subset',
 };
 
+const TARGETLESS_COMPARISON_OPERATORS = ['exists'];
+
 const isString = (value) =>
   typeof value === 'string' || value instanceof String;
 
@@ -36,7 +38,10 @@ const maybeReverseCondition = (pathToCheck, condition, attributes) => {
     condition,
   };
 
-  if (!condition.target || condition.comparison === 'exists') {
+  if (
+    !condition.target ||
+    TARGETLESS_COMPARISON_OPERATORS.includes(condition.comparison)
+  ) {
     return noOp;
   }
 


### PR DESCRIPTION
_depends on #120_

# Motivations

Adding a PR template to make it easier to remember to add reversed comparison operators when adding brand new comparison operators.