### PR TITLE
PRVT-119: support eager targets in reduce

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@
 
 ## Checklist
 
-- [] When adding a new comparison operator, a reversed comparison operator is
+- [ ] When adding a new comparison operator, a reversed comparison operator is
 also added, or the new comparison operator is added to the
 `TARGETLESS_COMPARISON_OPERATORS` list.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-runtime": "^6.26.0",
     "fast-deep-equal": "^3.1.3",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.curry": "^4.1.1",
     "util-deprecate": "^1.0.2"
   },
   "devDependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,7 +64,8 @@ export function merge(policies: AbacPolicy[]): AbacPolicy;
  */
 export function reduce(
   policy: AbacReducedPolicy,
-  attributes: object
+  attributes: object,
+  options?: { inlineTargets?: string[] }
 ): AbacReducedPolicy;
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,12 +43,23 @@ export function merge(policies: AbacPolicy[]): AbacPolicy;
 
 /**
  * Performs a synchronous reduction for whether the given policy might
- * allow the operations.  This function's intended use is for
- * client applications that need a simple check to disable
- * or annotate UI elements.
+ * allow the operations. This function's intended use is for client applications
+ * that need a simple check to disable or annotate UI elements.
+ *
+ * When a rule where the "key" is known and the "target" is unknown, a
+ * reversion and in-line replacement will occur so the policy can be
+ * evaluated immediately without consumers needing to be aware of the
+ * target attributes.
+ *
  * @param {object} policy - the policy to evaluate
  * @param {object} attributes - the attributes to use for the evaluation
- * @returns {object} the policy reduced to conditions involving attributes not not given
+ * @param {object} options optional function config
+ * @param {array} options.inlineTargets optional list of attribute paths that
+ * should be eagerly evaluated when reducing the policy. Eager evaluation makes
+ * sure that a rule with a known target will be inverted and replaced with the
+ * known value in-line.
+ * @returns {object} the policy reduced to conditions involving attributes not
+ * not given
  * @throws {Error} if the policy is invalid
  */
 export function reduce(

--- a/src/schemas/ReduceOptions.json
+++ b/src/schemas/ReduceOptions.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReduceOptions",
+  "description": "An options object that can be passed to the reduce function for configuration.",
+  "type": "object",
+  "properties": {
+    "eagerTargets": {
+      "type": "array",
+      "items": {
+        "type": ["string"]
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/ReduceOptions.json
+++ b/src/schemas/ReduceOptions.json
@@ -4,7 +4,7 @@
   "description": "An options object that can be passed to the reduce function for configuration.",
   "type": "object",
   "properties": {
-    "eagerTargets": {
+    "inlineTargets": {
       "type": "array",
       "items": {
         "type": ["string"]

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -6,4 +6,5 @@ module.exports = {
   Rule: require('./Rule.json'),
   Rules: require('./Rules.json'),
   OperationNames: require('./OperationNames.json'),
+  ReduceOptions: require('./ReduceOptions.json'),
 };

--- a/test/enforce.test.js
+++ b/test/enforce.test.js
@@ -1262,7 +1262,7 @@ test('rules can use suffixOf operator with value', (t) => {
     enforce('readData', policy, {
       patient: { favoriteSauce: undefined },
     }),
-    'returns false when the value is undefined'
+    'enforce undefined'
   );
 });
 

--- a/test/reduce.test.js
+++ b/test/reduce.test.js
@@ -471,7 +471,7 @@ test('that reversed conditions still correctly reduce final policy', (t) => {
   );
 });
 
-test('that known eager target attributes are replaced with in-line values', (t) => {
+test('that known inline target attributes are replaced with in-line values', (t) => {
   const initialPolicy = {
     rules: {
       readData: [
@@ -496,7 +496,10 @@ test('that known eager target attributes are replaced with in-line values', (t) 
           },
           'resource.anotherSecret': {
             comparison: 'equals',
-            target: 'user.invalidCustomAttributes.myCustomSecret',
+            // Validate that keys starting with the same name as the inline
+            // target don't actually get inlined. We want to check for
+            // exact paths.
+            target: 'user.customAttributesEdgeCase',
           },
           'resource.isActive': {
             comparison: 'equals',
@@ -531,7 +534,7 @@ test('that known eager target attributes are replaced with in-line values', (t) 
           },
           'resource.anotherSecret': {
             comparison: 'equals',
-            target: 'user.invalidCustomAttributes.myCustomSecret',
+            target: 'user.customAttributesEdgeCase',
           },
           'resource.isActive': {
             comparison: 'equals',
@@ -553,11 +556,12 @@ test('that known eager target attributes are replaced with in-line values', (t) 
             forbiddenOrgId: 'e-corp',
             isPastDue: true,
           },
+          customAttributesEdgeCase: 'some-value',
         },
         resource: { ownerId: 'testuser' },
       },
       {
-        eagerTargets: ['user.customAttributes'],
+        inlineTargets: ['user.customAttributes'],
       }
     ),
     expectedPolicy
@@ -595,21 +599,21 @@ test('validates reduce options', (t) => {
       reduce(
         policy,
         { user: { groups: [] } },
-        { invalidOption: ['1'], eagerTargets: ['user.customAttributes'] }
+        { invalidOption: ['1'], inlineTargets: ['user.customAttributes'] }
       ),
     'data should NOT have additional properties'
   );
   t.throws(
-    () => reduce(policy, { user: { groups: [] } }, { eagerTargets: [] }),
-    'data.eagerTargets should NOT have fewer than 1 items'
+    () => reduce(policy, { user: { groups: [] } }, { inlineTargets: [] }),
+    'data.inlineTargets should NOT have fewer than 1 items'
   );
   t.throws(
     () =>
-      reduce(policy, { user: { groups: [] } }, { eagerTargets: [{ id: 1 }] }),
-    'data.eagerTargets[0] should be string'
+      reduce(policy, { user: { groups: [] } }, { inlineTargets: [{ id: 1 }] }),
+    'data.inlineTargets[0] should be string'
   );
   t.notThrows(
-    () => reduce(policy, { user: { groups: [] } }, { eagerTargets: ['1'] }),
+    () => reduce(policy, { user: { groups: [] } }, { inlineTargets: ['1'] }),
     Error
   );
 });

--- a/test/reduce.test.js
+++ b/test/reduce.test.js
@@ -171,11 +171,10 @@ const assertComparisonNotReduced = (t, comparison, value = 'test') => {
   const expectedPolicy = {
     rules: {
       readData: [
-        // Inverted but not reduced.
         {
           'circle.owner.id': {
             comparison: COMPARISON_REVERSION_MAP[comparison],
-            value,
+            target: 'user.id',
           },
         },
       ],
@@ -282,75 +281,76 @@ test('reverses conditions when key value is known and target value is unknown', 
       ],
     },
   };
+
   const expectedPolicy = {
     rules: {
       readData: [
         {
           'resource.secret': {
             comparison: 'endsWith',
-            value: user.customAttributes.secret,
+            target: 'user.customAttributes.secret',
           },
           'resource.id': {
             comparison: 'equals',
-            value: user.customAttributes.id,
+            target: 'user.customAttributes.id',
           },
           'resource.patients': {
             comparison: 'includes',
-            value: user.customAttributes.patient,
+            target: 'user.customAttributes.patient',
           },
           'resource.patient': {
             comparison: 'in',
-            value: user.customAttributes.patients,
+            target: 'user.customAttributes.patients',
           },
           'resource.orgName': {
             comparison: 'notEquals',
-            value: user.customAttributes.orgName,
+            target: 'user.customAttributes.orgName',
           },
           'resource.forbiddenNames': {
             comparison: 'notIncludes',
-            value: user.customAttributes.name,
+            target: 'user.customAttributes.name',
           },
           'resource.forbiddenAction': {
             comparison: 'notIn',
-            value: user.customAttributes.actions,
+            target: 'user.customAttributes.actions',
           },
           'resource.rankOrder': {
             comparison: 'startsWith',
-            value: user.customAttributes.rank,
+            target: 'user.customAttributes.rank',
           },
           'resource.parentGroup': {
             comparison: 'prefixOf',
-            value: user.customAttributes.group,
+            target: 'user.customAttributes.group',
           },
           'resource.permissions': {
             comparison: 'superset',
-            value: user.customAttributes.permissions,
+            target: 'user.customAttributes.permissions',
           },
           'resource.allowedSuffix': {
             comparison: 'endsWith',
-            value: user.customAttributes.nameSuffix,
+            target: 'user.customAttributes.nameSuffix',
           },
           'resource.positions': {
             comparison: 'subset',
-            value: user.customAttributes.positions,
+            target: 'user.customAttributes.positions',
           },
           // Conditions with known target values should not be reversed.
           'user.customAttributes.lastNames': {
             comparison: 'includes',
-            value: resource.lastName,
+            target: 'resource.lastName',
           },
           // Conditions with unknown keys should not be reversed.
           'user.customAttributes.carrierNames': {
             comparison: 'notIncludes',
-            value: resource.carrierName,
+            target: 'resource.carrierName',
           },
           // Conditions with "value" should not be reversed.
           'user.customAttributes.favoriteSauce': {
             comparison: 'in',
             value: ['ketchup', 'mayo'],
           },
-          // 'exists' can't be used with a target, so assert that its condition
-          // wasn't reversed.
+          // 'exists' can't be used with a target, so assert that its
+          // condition wasn't reversed.
           'user.customAttributes.isActive': {
             comparison: 'exists',
           },
@@ -368,7 +368,7 @@ test('reverses conditions when key value is known and target value is unknown', 
   );
 });
 
-test('reverses conditions when necessary and reduces final policy correctly', (t) => {
+test('that reversed conditions still correctly reduce final policy', (t) => {
   const user = {
     customAttributes: {
       actions: ['HIKE', 'SNOWBOARD'],
@@ -447,19 +447,14 @@ test('reverses conditions when necessary and reduces final policy correctly', (t
       ],
     },
   };
-  const reducedPolicy = reduce(initialPolicy, {
-    user,
-    matchingResource,
-    privateResource,
-  });
   const attributes = {
     user,
     matchingResource,
     privateResource,
   };
+  const reducedPolicy = reduce(initialPolicy, attributes);
 
   t.deepEqual(reducedPolicy, expectedPolicy);
-  t.deepEqual(reduce(initialPolicy, attributes), expectedPolicy);
   // Enforce that the original policy is enforced in the same way as the
   // reduced policy with reversions.
   t.deepEqual(
@@ -476,7 +471,7 @@ test('reverses conditions when necessary and reduces final policy correctly', (t
   );
 });
 
-test('when custom user "target" attributes are known, they are replaced with in-line values', (t) => {
+test('that known eager target attributes are replaced with in-line values', (t) => {
   const initialPolicy = {
     rules: {
       readData: [
@@ -498,6 +493,10 @@ test('when custom user "target" attributes are known, they are replaced with in-
           'resource.secret': {
             comparison: 'equals',
             target: 'user.customAttributes.myCustomSecret',
+          },
+          'resource.anotherSecret': {
+            comparison: 'equals',
+            target: 'user.invalidCustomAttributes.myCustomSecret',
           },
           'resource.isActive': {
             comparison: 'equals',
@@ -530,6 +529,10 @@ test('when custom user "target" attributes are known, they are replaced with in-
             comparison: 'equals',
             value: 'secret-sauce',
           },
+          'resource.anotherSecret': {
+            comparison: 'equals',
+            target: 'user.invalidCustomAttributes.myCustomSecret',
+          },
           'resource.isActive': {
             comparison: 'equals',
             target: 'user.customAttributes.isActive',
@@ -540,17 +543,23 @@ test('when custom user "target" attributes are known, they are replaced with in-
   };
 
   t.deepEqual(
-    reduce(initialPolicy, {
-      user: {
-        customAttributes: {
-          myCustomPatients: ['patient-one', 'patient-two', 'patient-three'],
-          myCustomSecret: 'secret-sauce',
-          forbiddenOrgId: 'e-corp',
-          isPastDue: true,
+    reduce(
+      initialPolicy,
+      {
+        user: {
+          customAttributes: {
+            myCustomPatients: ['patient-one', 'patient-two', 'patient-three'],
+            myCustomSecret: 'secret-sauce',
+            forbiddenOrgId: 'e-corp',
+            isPastDue: true,
+          },
         },
+        resource: { ownerId: 'testuser' },
       },
-      resource: { ownerId: 'testuser' },
-    }),
+      {
+        eagerTargets: ['user.customAttributes'],
+      }
+    ),
     expectedPolicy
   );
 });
@@ -561,4 +570,46 @@ test('rules with undefined comparison targets should not be reduced', (t) => {
   assertComparisonNotReduced(t, 'includes', ['test']);
   assertComparisonNotReduced(t, 'notEquals');
   assertComparisonNotReduced(t, 'notIn', ['test']);
+});
+
+test('validates reduce options', (t) => {
+  const policy = {
+    rules: {
+      accessAdmin: [
+        {
+          'user.groups': {
+            comparison: 'includes',
+            value: 'some-id',
+          },
+        },
+      ],
+    },
+  };
+
+  t.throws(
+    () => reduce(policy, { user: { groups: [] } }, []),
+    'data should be object'
+  );
+  t.throws(
+    () =>
+      reduce(
+        policy,
+        { user: { groups: [] } },
+        { invalidOption: ['1'], eagerTargets: ['user.customAttributes'] }
+      ),
+    'data should NOT have additional properties'
+  );
+  t.throws(
+    () => reduce(policy, { user: { groups: [] } }, { eagerTargets: [] }),
+    'data.eagerTargets should NOT have fewer than 1 items'
+  );
+  t.throws(
+    () =>
+      reduce(policy, { user: { groups: [] } }, { eagerTargets: [{ id: 1 }] }),
+    'data.eagerTargets[0] should be string'
+  );
+  t.notThrows(
+    () => reduce(policy, { user: { groups: [] } }, { eagerTargets: ['1'] }),
+    Error
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,6 +4536,11 @@ lodash.clonedeepwith@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz#6ee30573a03a1a60d670a62ef33c10cf1afdbdd4"
   integrity sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=
 
+lodash.curry@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+  integrity sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==
+
 lodash.debounce@^4.0.3:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
## Motivation

We're adding support for `eagerTargets` so that we can specify which target attributes we want to replace with in-line values when reducing a policy. We're also bringing back previous functionality where we could have `undefined` `compareValue`s, since we're now back to not always replacing the inline target value. See https://lifeomic.slack.com/archives/C03AS9T658R/p1659980949891989 for more context.

## Checklist

- [x] When adding a new comparison operator, a reversed comparison operator is
also added, or the new comparison operator is added to the
`TARGETLESS_COMPARISON_OPERATORS` list.
