### PR TITLE
exclude babel-runtime from runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "ajv": "^6.5.0",
-    "babel-runtime": "^6.26.0",
     "fast-deep-equal": "^3.1.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.curry": "^4.1.1",
@@ -39,6 +38,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
+    "babel-runtime": "^6.26.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
## Motivation

`babel-runtime` is actually dev time dependency instead of a runtime one in this repo. This change will avoid bringing `babel-runtime` into `node_modules` of any downstream dependents who do not need it for runtime. saves about `8MB` from built artifact.

## Checklist

- [ ] When adding a new comparison operator, a reversed comparison operator is
also added, or the new comparison operator is added to the
`TARGETLESS_COMPARISON_OPERATORS` list.
